### PR TITLE
Adicionar passo no deploy para criar Firebase.json no VPS a partir de FIREBASE_KEYS (propósito: fornecer configuração do Firebase ao Backend sem armazenar arquivo no repositório)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,12 @@ jobs:
           printf '%s' '${{ secrets.FRONT_END_ENV_KEYS }}' > /home/administrator/deploys/docsphere/Front-End/.env
         "
 
+    - name: Create Firebase.json on VPS
+      run: |
+        ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
+          echo '${{ secrets.FIREBASE_KEYS }}' | base64 --decode > /home/administrator/deploys/docsphere/Back-End/Keys/Firebase.json
+        "
+
     - name: Deploy Docker Compose
       run: |
         ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "


### PR DESCRIPTION
## Descrição
* Breve resumo das mudanças: Adiciona um step no fluxo de deploy para criar Firebase.json no VPS a partir de FIREBASE_KEYS codificado em base64.
* Explicação concisa do **propósito geral do PR**: Garantir que a configuração do Firebase esteja disponível no backend durante o deploy sem armazenar Firebase.json no repositório, usando as secrets para decodificar e gravar o arquivo no servidor.

## Mudanças Principais
* **Nova etapa de deploy**: Criação de Firebase.json no VPS durante o fluxo de Deploy
  - Arquivos/Áreas impactadas: .github/workflows/deploy.yml
  - Descrição: Adiciona o passo "Create Firebase.json on VPS" que se conecta ao VPS via SSH e grava o Firebase.json decodificado a partir do secret FIREBASE_KEYS em /home/administrator/deploys/docsphere/Back-End/Keys/Firebase.json.
* **Configuração de secrets exigidos**:
  - DEPLOY_USER, DEPLOY_HOST, FIREBASE_KEYS
  - Descrição: Novos secrets utilizados pelo passo para autenticação, destino e conteúdo do Firebase.json.
* Observação sobre o conteúdo gerado:
  - FIREBASE_KEYS esperado como base64 do conteúdo de Firebase.json.

## Por que esta mudança?
* Justificativa: Habilita a disponibilização da configuração do Firebase no ambiente de produção sem commitar ou versionar o arquivo no repositório, reduzindo risco de vazamento e mantendo configurável por ambiente.
* Impacto esperado: Melhora na integração com Firebase do backend durante o deploy; não altera código-fonte existente; adiciona ponto de falha pequeno, dependente de secrets configurados corretamente.

## Como testar
* Pré-requisitos:
  - Secrets DEPLOY_USER, DEPLOY_HOST e FIREBASE_KEYS configurados no repositório (FIREBASE_KEYS deve conter o Firebase.json codificado em base64).
* Passos:
  1) Suba uma alteração simples para disparar o workflow de deploy.
  2) Verifique no log da etapa "Create Firebase.json on VPS" se houve sucesso no decode e criação do arquivo.
  3) Acesse o VPS e confirme que /home/administrator/deploys/docsphere/Back-End/Keys/Firebase.json foi criado com o conteúdo esperado.
  4) Prosiga com a etapa "Deploy Docker Compose" para validar que a aplicação utiliza o Firebase.json gerado (se aplicável).

## Observações Adicionais
* Pre-requisitos de diretório no VPS: assegurar que /home/administrator/deploys/docsphere/Back-End/Keys/ exista ou seja criado previamente.
* Segurança: o conteúdo de Firebase.json fica em secrets durante o processo de deploy, sendo gravado no servidor apenas nesse momento.
* Possíveis próximos passos: adicionar validação de schema do Firebase.json ou fallback caso o secret esteja ausente.