### PR TITLE
Atualiza configuração do Vite: corrige hosts permitidos e host de HMR para docsphere.mediacutsstudio.com. Propósito: alinhar o ambiente de desenvolvimento com o novo domínio/docsphere e manter HMR funcional.

### DIFF
--- a/Front-End/vite.config.ts
+++ b/Front-End/vite.config.ts
@@ -8,10 +8,10 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "0.0.0.0", 
     port: 4343,
-    allowedHosts: ["localhost", "accepted-poorly-maggot.ngrok-free.app", "www.support.mediacutsstudio.com"],
+    allowedHosts: ["localhost", "accepted-poorly-maggot.ngrok-free.app", "docsphere.mediacutsstudio.com"],
     hmr: {
       protocol: 'wss',
-      host: 'support.mediacutsstudio.com', 
+      host: 'docsphere.mediacutsstudio.com', 
     },
     watch: {
       ignored: ['**/node_modules/**'],


### PR DESCRIPTION
## Descrição
* Atualização das configurações do servidor de desenvolvimento no Vite para refletir o novo domínio docsphere.mediacutsstudio.com.
* Ajustes em allowedHosts e no host do HMR para garantir conectividade segura e estável durante o desenvolvimento.

## Mudanças Principais
* Configuração do servidor de desenvolvimento (Front-End/vite.config.ts).
  - Removido o domínio antigo (www.support.mediacutsstudio.com) de allowedHosts e adicionado docsphere.mediacutsstudio.com.
  - Atualizado o hmr.host de support.mediacutsstudio.com para docsphere.mediacutsstudio.com.
  - Mantido o restante da configuração (host, port, watch, etc.).

## Por que esta mudança?
* Alinhar o ambiente de desenvolvimento com o novo domínio docsphere.mediacutsstudio.com para permitir acesso adequado e comunicação entre o navegador e o servidor de desenvolvimento.
* Garantir que o HMR funcione com WebSocket seguro (WSS) usando o host correto, evitando falhas de conexão durante o desenvolvimento.

## Como testar
1) Iniciar o servidor de desenvolvimento (ex.: npm run dev ou yarn dev).
2) Acessar via docsphere.mediacutsstudio.com na porta configurada (ex.: http://docsphere.mediacutsstudio.com:4343).
3) Verificar que o hot module replacement (HMR) funciona ao editar arquivos (sem erros de conexão de host).
4) Em ambientes com proxies ou domínios customizados, confirmar que não há mensagens de blocked host e que as mudanças são refletidas em tempo real.

## Observações Adicionais (Opcional)
* Esta mudança atinge apenas a configuração de desenvolvimento. Não há alterações de produção ou build. Se houver dependências ou fluxos que referenciem os domínios antigos, atualizá-los para docsphere.mediacutsstudio.com se aplicável.