### PR TITLE
Suporte a upload por streaming e melhorias no backend; infraestrutura de PR e CI atualizada

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,25 @@
+name: Processar Pull Request
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  call-pr-ai-service:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug JSON
+        run: |
+          echo "Repository: ${{ github.repository }}"
+          echo "PR number: ${{ github.event.pull_request.number }}"
+
+      - name: Chamar API
+        run: |
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "X-API-TOKEN: ${{ secrets.PRAI_API_TOKEN }}" \
+            -d "{
+              \"repository\": \"${{ github.repository }}\",
+              \"pr_number\": \"${{ github.event.pull_request.number }}\"
+            }" \
+            https://api.softwareai.site/api/prai/gen

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Certifi/
 mvp.md
 
 
+Nginx/

--- a/Back-End/Modules/upload_.py
+++ b/Back-End/Modules/upload_.py
@@ -1,9 +1,11 @@
-# Internal-server\.py
+# Internal-server.py (parte relevante)
 import os
 import json
 import requests
 import logging
-diretorio_script = os.path.dirname(__file__) 
+from typing import IO
+
+diretorio_script = os.path.dirname(__file__)
 os.makedirs(os.path.join(diretorio_script, '../', 'Logs'), exist_ok=True)
 
 logger = logging.getLogger(__name__)
@@ -16,7 +18,29 @@ console_handler.setFormatter(formatter)
 logger.addHandler(file_handler)
 logger.addHandler(console_handler)
 
-def upload_(name_project, VIDEO_FILE_PATH, USER_ID_FOR_TEST, 
+def _guess_filename_from_fileobj(fileobj):
+    # tenta obter nome do objeto (ex: handle.name)
+    name = getattr(fileobj, "name", None)
+    if isinstance(name, str):
+        return os.path.basename(name)
+    # tenta outros atributos (ex: filename)
+    name2 = getattr(fileobj, "filename", None)
+    if isinstance(name2, str):
+        return os.path.basename(name2)
+    return None
+
+def _get_content_length(fileobj: IO):
+    # tenta calcular tamanho sem consumir stream (somente para seekable)
+    try:
+        cur = fileobj.tell()
+        fileobj.seek(0, os.SEEK_END)
+        size = fileobj.tell()
+        fileobj.seek(cur, os.SEEK_SET)
+        return size
+    except Exception:
+        return None
+
+def upload_(name_project, VIDEO_FILE_PATH, USER_ID_FOR_TEST,
             type_project="files",
             title='',
             description='',
@@ -26,20 +50,21 @@ def upload_(name_project, VIDEO_FILE_PATH, USER_ID_FOR_TEST,
             urltumbnail='',
             justificativa='',
             sentimento_principal='',
-            potencial_de_viralizacao='',
-
-
-            ):
+            potencial_de_viralizacao=''):
+    """
+    Suporta:
+      - VIDEO_FILE_PATH = '/caminho/para/arquivo.mp4'  (string com path)  -> multipart upload (compatibilidade antiga)
+      - VIDEO_FILE_PATH = fileobj (objeto com .read())              -> raw streaming (headers X-Filename, X-Metadata)
+      - VIDEO_FILE_PATH = {'fileobj': fileobj, 'filename': 'nome.mp4'} -> força nome quando fileobj não tem .name
+    """
     UPLOAD_URL = "https://videomanager.api.mediacutsstudio.com"
 
     if type_project == "files":
-            
         video_metadata = {
             "projectName": name_project,
             "type_project": type_project,
-
         }
-    elif type_project == "video":
+    else:
         video_metadata = {
             "projectName": name_project,
             "type_project": "video",
@@ -54,49 +79,92 @@ def upload_(name_project, VIDEO_FILE_PATH, USER_ID_FOR_TEST,
             "potencial_de_viralizacao": potencial_de_viralizacao
         }
 
-    if not os.path.exists(VIDEO_FILE_PATH):
-        logger.info(f"Erro: O arquivo '{VIDEO_FILE_PATH}' não foi encontrado.")
-        logger.info("Por favor, crie um arquivo MP4 com este nome ou ajuste o caminho.")
-        exit()
+    # ----- Caso 1: caminho de arquivo (string path) -----
+    if isinstance(VIDEO_FILE_PATH, str):
+        if not os.path.exists(VIDEO_FILE_PATH):
+            logger.info(f"Erro: O arquivo '{VIDEO_FILE_PATH}' não foi encontrado.")
+            return None
 
+        try:
+            with open(VIDEO_FILE_PATH, 'rb') as video_file:
+                files = {
+                    'file': (os.path.basename(VIDEO_FILE_PATH), video_file, 'video/mp4')
+                }
+                data = {
+                    'metadata': json.dumps(video_metadata)
+                }
+                headers = {
+                    'X-User-Id': USER_ID_FOR_TEST
+                }
+                logger.info(f"Tentando enviar '{VIDEO_FILE_PATH}' para {UPLOAD_URL} (multipart)...")
+                logger.info(f"Com metadados: {json.dumps(video_metadata, indent=2)}")
+                response = requests.post(f"{UPLOAD_URL}/api/upload-video", files=files, data=data, headers=headers, timeout=300)
+
+                if response.status_code in (200, 201):
+                    logger.info("Upload bem-sucedido (multipart).")
+                    payload = response.json()
+                    return payload.get('video_id') or payload.get('item_id') or None
+                else:
+                    logger.info(f"Erro no upload (multipart): Código {response.status_code}")
+                    try:
+                        logger.info(json.dumps(response.json(), indent=2))
+                    except Exception:
+                        logger.info(response.text)
+                    return None
+
+        except Exception as e:
+            logger.exception(f"Erro ao enviar arquivo (multipart): {e}")
+            return None
+
+    # ----- Caso 2: dicionário com fileobj e filename -----
+    if isinstance(VIDEO_FILE_PATH, dict) and 'fileobj' in VIDEO_FILE_PATH:
+        fileobj = VIDEO_FILE_PATH['fileobj']
+        filename = VIDEO_FILE_PATH.get('filename') or _guess_filename_from_fileobj(fileobj) or 'upload.bin'
+
+    # ----- Caso 3: file-like object direto -----
+    elif hasattr(VIDEO_FILE_PATH, 'read'):
+        fileobj = VIDEO_FILE_PATH
+        filename = _guess_filename_from_fileobj(fileobj) or 'upload.bin'
+
+    else:
+        logger.info("Parâmetro VIDEO_FILE_PATH inválido. Deve ser path (string), file-like ou dict {'fileobj', 'filename'}.")
+        return None
+
+    # -------- Envio em modo stream (raw body) --------
     try:
-        with open(VIDEO_FILE_PATH, 'rb') as video_file:
-            files = {
-                'file': (os.path.basename(VIDEO_FILE_PATH), video_file, 'video/mp4')
-            }
-            data = {
-                'metadata': json.dumps(video_metadata) 
-            }
-            headers = {
-                'X-User-Id': USER_ID_FOR_TEST 
-            }
-            logger.info(f"Tentando enviar '{VIDEO_FILE_PATH}' para {UPLOAD_URL}...")
-            logger.info(f"Com metadados: {json.dumps(video_metadata, indent=2)}")
-            response = requests.post(F"{UPLOAD_URL}/api/upload-video", files=files, data=data, headers=headers)
+        # calcula content-length quando possível
+        content_length = _get_content_length(fileobj)
+        headers = {
+            'X-User-Id': USER_ID_FOR_TEST,
+            'X-Filename': filename,
+            'X-Metadata': json.dumps(video_metadata),
+            # content-type de corpo bruto
+            'Content-Type': 'application/octet-stream'
+        }
+        if content_length is not None:
+            headers['Content-Length'] = str(content_length)
 
-            if response.status_code == 201 or response.status_code == 200:
-                logger.info("\nUpload bem-sucedido!")
-                logger.info("Resposta do servidor:")
+        logger.info(f"Tentando enviar stream '{filename}' para {UPLOAD_URL} (stream raw)...")
+        logger.info(f"Com metadados: {json.dumps(video_metadata, indent=2)}, Content-Length: {content_length}")
+
+        # requests aceita fileobj em data para streamar o corpo (não usa multipart)
+        response = requests.post(f"{UPLOAD_URL}/api/upload-video", data=fileobj, headers=headers, timeout=300)
+
+        if response.status_code in (200, 201):
+            logger.info("Upload bem-sucedido (stream).")
+            payload = response.json()
+            return payload.get('video_id') or payload.get('item_id') or None
+        else:
+            logger.info(f"Erro no upload (stream): Código {response.status_code}")
+            try:
                 logger.info(json.dumps(response.json(), indent=2))
-                payload = response.json()
-                ID = payload['video_id']
-                logger.info(f"ID: {ID}")
-                return ID
-            else:
-                logger.info(f"\nErro no upload: Código de status {response.status_code}")
-                logger.info("Resposta do servidor:")
-                try:
-                    logger.info(json.dumps(response.json(), indent=2))
-                except json.JSONDecodeError:
-                    print(response.text) # Se a resposta não for JSON
-                logger.info("\nCertifique-se de que seu servidor Flask está rodando e o endpoint está acessível.")
-                logger.info("Verifique também se o 'USER_ID_FOR_TEST' e o 'UPLOAD_URL' estão corretos.")
+            except Exception:
+                logger.info(response.text)
+            return None
 
-    except FileNotFoundError:
-        logger.info(f"Erro: O arquivo '{VIDEO_FILE_PATH}' não foi encontrado.")
-    except requests.exceptions.ConnectionError:
-        logger.info("Erro de conexão: O servidor não está acessível.")
-        logger.info("Certifique-se de que o backend Flask está rodando em 'http://localhost:5000'.")
+    except requests.exceptions.RequestException as e:
+        logger.exception(f"Erro de conexão/requests durante upload stream: {e}")
+        return None
     except Exception as e:
-        logger.info(f"Ocorreu um erro inesperado: {e}")
-
+        logger.exception(f"Erro inesperado durante upload stream: {e}")
+        return None

--- a/Back-End/Test/upload.py
+++ b/Back-End/Test/upload.py
@@ -1,20 +1,77 @@
-from Modules.upload_ import *
+# exemplo_stream_upload.py
+from Modules.upload_ import upload_
+import io
+import os
 
-
-name_project= "teste"
-VIDEO_FILE_PATH = r"E:\Users\Media Cuts DeV\Downloads\WorkEnv\Docsphere\subclip_vertical_1.mp4"
+name_project = "requirements"
+VIDEO_FILE_PATH = r"E:\Users\Media Cuts DeV\Downloads\WorkEnv\Docsphere\Back-End\requirements.txt"
 USER_ID_FOR_TEST = "freitasalexandre810@gmail_com"
 
-upload_(name_project, VIDEO_FILE_PATH, USER_ID_FOR_TEST,
-        type_project="video",
-        title='teste',
-        description='teste',
-        hashtags='#teste',
+# ------------------------
+# MODO A: passar file-like (stream direto do disco)
+# ------------------------
+print("Modo A: stream do arquivo no disco...")
+if os.path.exists(VIDEO_FILE_PATH):
+    with open(VIDEO_FILE_PATH, "rb") as f:
+        # NÃO leia todo o arquivo na memória; passe o fileobj diretamente
+        video_id = upload_(
+            name_project,
+            f,  # file-like -> upload_ envia em stream
+            USER_ID_FOR_TEST,
+            type_project="files",
+            title='teste',
+            description='teste',
+            hashtags='#teste',
+            minutagemdeInicio='00:00:00',
+            minutagemdeFim='00:00:00',
+            urltumbnail='testeurl',
+            justificativa='none',
+            sentimento_principal='none',
+            potencial_de_viralizacao='none',
+        )
+
+    if video_id:
+        print("Upload OK (modo A). video_id:", video_id)
+    else:
+        print("Upload falhou (modo A).")
+else:
+    print("Arquivo não encontrado:", VIDEO_FILE_PATH)
+
+# ------------------------
+# MODO B: passar bytes em memória (BytesIO) e forçar filename
+# ------------------------
+print("\nModo B: usar BytesIO e forçar filename...")
+try:
+    with open(VIDEO_FILE_PATH, "rb") as f_src:
+        data = f_src.read()  # aqui você carrega em memória (só para exemplo)
+    buf = io.BytesIO(data)
+    buf.seek(0)  # crucial: coloque o ponteiro no início antes de enviar
+
+    payload = {
+        "fileobj": buf,
+        "filename": "requirements.txt"
+    }
+
+    video_id2 = upload_(
+        name_project,
+        payload,  # dict com fileobj + filename -> upload_ envia em stream
+        USER_ID_FOR_TEST,
+        type_project="files",
+        title='teste-2',
+        description='teste-2',
+        hashtags='#teste2',
         minutagemdeInicio='00:00:00',
         minutagemdeFim='00:00:00',
         urltumbnail='testeurl',
         justificativa='none',
         sentimento_principal='none',
         potencial_de_viralizacao='none',
-    
     )
+
+    if video_id2:
+        print("Upload OK (modo B). video_id:", video_id2)
+    else:
+        print("Upload falhou (modo B).")
+
+except Exception as e:
+    print("Erro no modo B:", e)

--- a/build_main.py
+++ b/build_main.py
@@ -10,4 +10,4 @@ def executar_comando(comando):
     subprocess.run(comando, shell=True)
 
 
-executar_comando("docker-compose up --build -d ")
+executar_comando("docker-compose up --build -d nginx_proxy_server")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,21 @@ version: '3.8'
 
 services:
 
+  nginx_proxy_server:
+    build:
+      context: ./Nginx
+      dockerfile: Dockerfile
+    container_name: nginx_proxy_server
+    ports:
+      - "80:80"
+      - "443:443"
+    # depends_on:
+    #   - frontend_docserver
+    #   - docserver_api_1
+    restart: "no"
+    networks:
+      - rede_externa
+
   frontend_docserver:
     container_name: frontend_docserver
     build:
@@ -49,7 +64,7 @@ services:
       "--timeout-keep-alive", "3600"
     ]
     volumes:
-      # - ./Back-End:/app
+      - ./Back-End:/app
       - files_data:/app/videos
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:4251"] 


### PR DESCRIPTION
## Descrição
* Breve resumo: introduz suporte a upload de vídeos por streaming, refatora o endpoint de upload, adiciona utilitários para nomes de projetos seguros e calcula o tamanho de stream, e aumenta a robustez do armazenamento de arquivos e metadados. Também atualiza a infraestrutura (NGINX proxy) e adiciona fluxo de CI para PRs.
* Explicação concisa do propósito geral do PR: permitir uploads de vídeos sem carregar tudo na memória, suportar diferentes formas de entrada (caminho de arquivo, stream/file-like, ou dict com fileobj e filename), sanitizar nomes de projetos para evitar problemas de paths, persistir arquivos no servidor e atualizar metadados no Firebase, além de preparar a infraestrutura para proxy Nginx e automação de PRs.

## Mudanças Principais
* Backend - Módulo de upload (Back-End/Modules/upload_.py)
  - Adicionadas helpers: _guess_filename_from_fileobj, _get_content_length para suportar streaming sem consumir o arquivo inteiro na memória.
  - Refatoração de upload_ para suportar três modos de entrada:
    1) VIDEO_FILE_PATH como string (caminho) usando multipart; 2) VIDEO_FILE_PATH como file-like/stream direto; 3) VIDEO_FILE_PATH como dict {'fileobj', 'filename'} para forçar nome.
  - Preparação de metadata e envio robusto com log detalhado.
  - Tratamento de conteúdo streaming com cabeçalhos X-User-Id, X-Filename e X-Metadata, e cálculo opcional de Content-Length.
  - Tratamento de erros mais explícito e mensagens de log para diagnóstico.
  - Arquitetura preparada para enviar para backend remoto (URL de upload) sem bloquear a memória com leitura completa do arquivo.

* Backend - Endpoint de upload (Back-End/server.py)
  - Nova implementação do endpoint /api/upload-video para suportar multipart e fluxo de streaming.
  - Sanitização de nomes de projetos e prevenção de path traversal, com CHUNK_SIZE para streaming.
  - Criação de diretórios seguros e salvamento do arquivo com prefixo de video_id.
  - Suporte a dois modos de persistência: caminho no servidor (multipart) e streaming/gravado em disco (stream).
  - Atualização de metadados no Firebase para tipos de projeto video e files, incluindo informações como filename, serverFilePath, uploadedAt, size e status.
  - Tratamento de erros, limpeza de arquivos parciais em caso de falha e lógica para registrar o progresso.

* Testes de upload (Back-End/Test/upload.py)
  - Exemplo com Modo A (stream direto do arquivo no disco via file-like) e Modo B (uso de BytesIO com filename forçado).
  - Demonstração de diferentes vias de envio para validar o novo fluxo de upload.

* Infraestrutura e CI (CI/Infra)
  - build_main.py: ajustado para iniciar o nginx_proxy_server durante o desenvolvimento.
  - docker-compose.yml: adicionado serviço nginx_proxy_server, com build a partir de Nginx/, portas 80/443 expostas, e rede externa configurada.
  - .gitignore: adicionada a pasta Nginx/ para evitar commit de artefatos de proxy.

* CI de PRs (GitHub Actions)
  - .github/workflows/pr.yml: nova etapa para processar PR com serviço externo de AI, útil para validação automatizada de PRs.

## Por que esta mudança?
* Performance e robustez: Uploads por streaming reduzem uso de memória e permite lidar com arquivos grandes sem carregar tudo na memória do processo.
* Segurança e confiabilidade: Sanitização de nomes de projetos evita vulnerabilidades de path traversal; verificação de tipos de arquivo e validação de metadata aumentam a confiabilidade do backend.
* Integração e visibilidade: Metadados são persistidos no Firebase com estados atualizados, dando visibilidade sobre status e histórico de uploads.
* Infraestrutura pronta para produção: Adição de nginx_proxy_server prepara a infraestrutura para proxy reverso, balanceamento e TLS em PRs/domínios reais.

## Como testar
1) Iniciar a infraestrutura (com Docker):
   - Executar docker-compose up --build -d (ou conforme a configuração de início local) e verificar que nginx_proxy_server sobe junto aos demais serviços.
2) Teste multipart (upload tradicional):
   - curl -X POST -F file=@/path/to/video.mp4 -F metadata='{"projectName":"teste-projeto","type_project":"video","title":"teste"}' http://localhost/api/upload-video
   - Esperar 200/201 e obter o video_id na resposta.
3) Teste streaming (raw body com headers):
   - curl -X POST --data-binary @/path/to/video.mp4 \
     -H "X-User-Id: user@example.com" \
     -H "X-Filename: video.mp4" \
     -H "X-Metadata: {\"projectName\": \"teste-projeto\",\"type_project\":\"video\"}" \
     http://localhost/api/upload-video
   - Esperar 200/201 e validar retorno de video_id.
4) Valide metadados no Firebase (ou DB conectada): verifique o nó correspondente a projects/<user>/<project>/videos/<video_id> com type_project, filename, serverFilePath, uploadedAt e status.
5) Teste de fallback/erro: enviar com metadata inválido, arquivo não permitido, ou diretórios inexistentes para verificar mensagens de erro apropriadas.
6) Verifique o fluxo de PR: abra um PR e confirme o job de PR AI service no CI, se aplicável.

## Observações Adicionais (Opcional)
* Dependências: o backend já utiliza requests, logging e Firebase wrapper; ensure que as credenciais/configs de Firebase e do UPLOAD_URL estejam disponíveis no ambiente de execução.
* Compatibilidade: a nova implementação mantém compatibilidade com o fluxo multipart existente, ao mesmo tempo oferecendo streaming como opção preferencial para grandes arquivos.
* Próximos passos potenciais: adicionar testes automatizados de integração para o endpoint /api/upload-video, e documentação de uso do novo modo de streaming (headers X-Filename e X-Metadata).
