### PR TITLE
Corrige path de exclusão do diretório Front-End/node_modules no rsync de deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
         rsync -avz --delete ./ ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/home/administrator/deploys/docsphere \
           --exclude node_modules \
           --exclude .git \
-          --exclude front-end/node_modules
+          --exclude Front-End/node_modules
 
     - name: Make dir on VPS
       run: |


### PR DESCRIPTION
## Descrição
* Breve resumo das mudanças: Atualização do comando rsync no workflow de deploy para excluir Front-End/node_modules (com a capitalização correta).
* Explicação concisa do **propósito geral do PR**: Garantir que as dependências do Front-End não sejam sincronizadas para o servidor, reduzindo o tempo de deploy e evitando conflitos de permissões no VPS.

## Mudanças Principais
* Corrige o caminho de exclusão no rsync do deploy
  * Arquivos impactados: .github/workflows/deploy.yml
  * Descrição: Substitui --exclude front-end/node_modules por --exclude Front-End/node_modules para refletir a estrutura real do diretório e evitar sincronização desnecessária.

## Por que esta mudança?
* Justificativa: Corrige uma falha no pipeline de deploy causada pela diferença de capitalização no caminho do diretório, assegurando que a pasta Front-End/node_modules não seja sincronizada para o VPS. Resultado esperado: deploy mais rápido e menos tráfego de rede.

## Como testar
* Passos:
  1. Acione o workflow de deploy (ou faça push para a branch de deploy).
  2. Verifique os logs do job de deploy para confirmar o uso de --exclude Front-End/node_modules no rsync.
  3. Confirme que a pasta Front-End/node_modules não é transferida para o servidor.
  4. Opcional: conecte-se ao VPS e verifique que não há node_modules na pasta de destino.

## Observações Adicionais (Opcional)
* Não há alterações em código de produção; apenas ajuste no fluxo de deploy. Se houver renomeação de pastas, manter consistência de casing em futuros commits.