### PR TITLE
Remover etapa de permissão no deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,12 +31,6 @@ jobs:
         echo "known_hosts:"
         cat ~/.ssh/known_hosts 
 
-    - name: permissão
-      run: |
-        ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "
-          sudo chown -R ${{ secrets.DEPLOY_USER }}: $HOME/deploys/docsphere
-          sudo chmod -R u+rwX $HOME/deploys/docsphere
-        "
     - name: Copy entire project to VPS
       run: |
         rsync -avz --delete ./ ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/home/administrator/deploys/docsphere \


### PR DESCRIPTION
## Descrição
* Remoção da etapa de permissão do fluxo de deploy no GitHub Actions.
* Explicação concisa do propósito: a tarefa que executava chown/chmod via SSH foi removida; o rsync subsequente já garante permissões adequadas ou o usuário de deploy já possui as permissões necessárias, simplificando o pipeline e evitando uso de sudo remoto.

## Mudanças Principais
* Remoção da etapa de permissão no arquivo .github/workflows/deploy.yml.
  - Arquivos/áreas impactadas: .github/workflows/deploy.yml. Descrição: removeu o bloco de código que executava chown -R e chmod -R no servidor de destino.
* Mantida a etapa de cópia do projeto para o VPS.
  - Descrição: a etapa "Copy entire project to VPS" com rsync permanece para transferir os arquivos, sem alterações de permissões adicionais no pipeline.

## Por que esta mudança?
* Justificativa: simplifica o fluxo de deploy, evita dependência de privilégios de sudo no host remoto e confia na transferência com rsync para manter as permissões ou já utiliza permissões definidas no servidor.
* Impacto esperado: redução de pontos de falha relacionados a permissões, melhoria de segurança e pipeline mais simples.

## Como testar
* Rode o pipeline de deploy em ambiente de CI/CD e verifique que não há etapas falhando relacionadas a permissões.
* Confirme no servidor de destino que o diretório /home/administrator/deploys/docsphere recebeu os arquivos e tem as permissões apropriadas para o usuário de deploy.
* Em staging/produção, valide que a aplicação lê os arquivos transferidos sem erros de permissão.

## Observações Adicionais (Opcional)
* Sem mudanças de dependências. Caso ocorram discrepâncias de permissões, pode-se reintroduzir uma etapa de ajuste de permissões com controles mais restritos (sem sudo ou com usuário específico).